### PR TITLE
Fix lỗi không bỏ qua tiết học bị trùng

### DIFF
--- a/js/schedule.js
+++ b/js/schedule.js
@@ -111,7 +111,8 @@ const drawSchedule = (arr) => {
         let idCell = start + '_' + day;
         let cell = document.getElementById(idCell);
         if (cell != null) {
-            if (cell.className == 'course') {
+            // cell.classList == 'course' : bị bỏ qua vì className không chỉ có mỗi course
+            if (cell.classList.contains('course')) {
                 continue;
             }
             let tengiaovien = "";


### PR DESCRIPTION
Vì không bỏ qua tiết học bị trùng, nên khi tiết học bị trùng sẽ lấy theo tiết có total là lớn nhất và loại bỏ các cột từ start + 1 cho đến end. Tuy nhiên, cuối cùng lại hiển thị rowSpan theo total nhỏ nhất, khiến cho thời khóa biểu bị lệch do xóa dư một số cột.